### PR TITLE
[TESTS] Truncate tests fully implemented

### DIFF
--- a/src/comparison/s21_is_equal.c
+++ b/src/comparison/s21_is_equal.c
@@ -1,7 +1,6 @@
 #include "../s21_decimal.h"
 
-static bool bits_eq(const int bits_a[4],
-                    const int bits_b[4]) {
+static bool bits_eq(const unsigned bits_a[4], const unsigned bits_b[4]) {
     return bits_a[0] == bits_b[0] && bits_a[1] == bits_b[1] &&
            bits_a[2] == bits_b[2] && bits_a[3] == bits_b[3];
 }

--- a/src/tests/helpers/int128_converters.c
+++ b/src/tests/helpers/int128_converters.c
@@ -1,5 +1,12 @@
 #include "../s21_decimal_test.h"
 
+__int128_t int128_pow(int val, int exp) {
+    __int128_t res = 1;
+    while (exp--)
+        res *= val;
+    return res;
+}
+
 s21_decimal ll_to_decimal(long long val) {
     s21_decimal res = {0};
     if (val < 0) {

--- a/src/tests/helpers/random_values.c
+++ b/src/tests/helpers/random_values.c
@@ -2,9 +2,7 @@
 
 static void set_random_pair_sign(s21_decimal *dec, mpz_t *in_mpz_copy);
 
-#ifdef DEBUG
-static void debug_print_pair(s21_decimal *dec, mpz_t *big, bool exp_applied);
-#endif
+void debug_print_pair(s21_decimal *dec, mpz_t *big, bool exp_applied);
 
 static void get_random_binary_string(s21_decimal *dec, char *mpz_bin_str,
                                      int size);
@@ -14,7 +12,7 @@ int get_random_pair(s21_decimal *in, mpz_t *in_mpz_copy, int size) {
 
     get_random_binary_string(in, mpz_bin_str, size);
 
-    int exp = get_rand(0, 28);
+    int exp = get_rand(0, 3);
     set_exponent(in, exp);
 
     bool res = mpz_set_str(*in_mpz_copy, mpz_bin_str, 2);
@@ -59,9 +57,7 @@ static void get_random_binary_string(s21_decimal *in, char *mpz_bin_str,
         in->bits[j] = reverse_bits(in->bits[j]);
 }
 
-#ifdef DEBUG
-
-static void debug_print_pair(s21_decimal *dec, mpz_t *big, bool exp_applied) {
+void debug_print_pair(s21_decimal *dec, mpz_t *big, bool exp_applied) {
     printf("=================\n");
 
     if (exp_applied)
@@ -70,15 +66,14 @@ static void debug_print_pair(s21_decimal *dec, mpz_t *big, bool exp_applied) {
         printf("Before exponent: \n");
 
     printf("Exponent value: [%d]\n", get_exponent(*dec));
-    printf("Decimal: \n");
+    printf("Decimal:");
     print_bits_no_exp(*dec);
+    printf("Mpz_bin:");
     print_mpz_binary(*big);
-    printf("MPZ decimal: \n");
+    printf("MPZ_dec: ");
     print_mpz_decimal(*big);
     printf("=================\n");
 }
-
-#endif
 
 static void set_random_pair_sign(s21_decimal *dec, mpz_t *in_mpz_copy) {
     if (get_rand(0, 1)) {

--- a/src/tests/math_tests/test_s21_add.c
+++ b/src/tests/math_tests/test_s21_add.c
@@ -1,5 +1,5 @@
 #include "../s21_decimal_test.h"
-#define DEBUG
+
 START_TEST(overflow_test) {
     s21_decimal a = {0};
     s21_decimal b = {0};
@@ -84,13 +84,13 @@ START_TEST(random_decimal_exp) {
 #ifdef DEBUG
     print_bits_r(dec_sum);
     print_bits_r(short_dec);
-    // printf("DEC: %d \t SHORT: %d \n", dec_sum.bits[0], short_dec.bits[0]);
-    // printf("DEC: %d \t SHORT: %d \n", dec_sum.bits[1], short_dec.bits[1]);
-    // printf("DEC: %d \t SHORT: %d \n", dec_sum.bits[2], short_dec.bits[2]);
-    // printf("DEC: %d \t SHORT: %d \n", dec_sum.bits[3], short_dec.bits[3]);
+    printf("DEC: %u \t SHORT: %u \n", dec_sum.bits[0], short_dec.bits[0]);
+    printf("DEC: %u \t SHORT: %u \n", dec_sum.bits[1], short_dec.bits[1]);
+    printf("DEC: %u \t SHORT: %u \n", dec_sum.bits[2], short_dec.bits[2]);
+    printf("DEC: %u \t SHORT: %u \n", dec_sum.bits[3], short_dec.bits[3]);
 #endif
 
-    ck_assert_int_eq(abs(dec_sum.bits[0]), abs(short_dec.bits[0]));
+    ck_assert_int_eq(dec_sum.bits[0], short_dec.bits[0]);
 }
 END_TEST
 
@@ -111,16 +111,16 @@ END_TEST
 /* } */
 /* END_TEST */
 
-/* START_TEST(edge_cases) { */
-/*     s21_decimal a = {{1, 0, 0, get_rand(0, INT_MAX)}}; */
-/*     s21_decimal b = get_random_decimal(3, get_rand(1, 20)); */
-/*     s21_decimal got = {0}; */
-/*     set_random_sign(&a); */
-/*     set_random_sign(&b); */
-/*     int code = s21_add(a, b, &got); */
-/*     ck_assert_int_eq(code, ARITHMETIC_OK); */
-/* } */
-/* END_TEST */
+START_TEST(edge_cases) {
+    s21_decimal a = {{1, 0, 0, get_rand(0, INT_MAX)}};
+    s21_decimal b = get_random_decimal(3, get_rand(1, 20));
+    s21_decimal got = {0};
+    set_random_sign(&a);
+    set_random_sign(&b);
+    int code = s21_add(a, b, &got);
+    ck_assert_int_eq(code, ARITHMETIC_OK);
+}
+END_TEST
 
 Suite *suite_s21_add(void) {
     Suite *s = suite_create(PRETTY_PRINT("s21_add"));
@@ -128,10 +128,10 @@ Suite *suite_s21_add(void) {
 
     /* Add works great. Tested with binary calculator */
 
-    // tcase_add_loop_test(tc, gcc_128_bits, 0, 100);
-    // tcase_add_loop_test(tc, random_decimal_exp, 0, 100);
+    tcase_add_loop_test(tc, gcc_128_bits, 0, 100);
+    tcase_add_loop_test(tc, random_decimal_exp, 0, 100);
     /* tcase_add_loop_test(tc, sum_with_arbitrary_exp, 0, 10000); */
-    /* tcase_add_loop_test(tc, edge_cases, 0, 10000); */
+    tcase_add_loop_test(tc, edge_cases, 0, 10000);
     tcase_add_test(tc, overflow_test);
 
     suite_add_tcase(s, tc);

--- a/src/tests/rounding_tests/test_s21_truncate.c
+++ b/src/tests/rounding_tests/test_s21_truncate.c
@@ -1,24 +1,35 @@
 #include "../s21_decimal_test.h"
 
-/* TODO: Implement tests using gmp(suicide) */
-/* simply dividing by 10 to truncate */
-/* i.e 764183413481 / 10000 = 76418341 */
+START_TEST(gcc_128_bits) {
+    /* get random value */
+    __int128_t a = llabs(get_random_ll() * rand());
 
-START_TEST(simple_truncate) {
-    s21_decimal value = get_random_decimal(3, 28);
+    /* apply exponent */
+    int exp = get_rand(0, 10);
+    __int128_t b = int128_pow(10, exp);
+    __int128_t sum = a / b;
+
+    /* get expected */
+    s21_decimal expected = bigint_to_decimal(sum);
+
+    s21_decimal got = bigint_to_decimal(a);
+    set_exponent(&got, exp);
+
     s21_decimal res = {0};
 
-    int ret = s21_truncate(value, &res);
+    int ret = s21_truncate(got, &res);
 
 #ifdef DEBUG
     printf("before=");
-    print_bits_r(value);
-    printf("after= ");
+    print_bits_r(got);
+    printf("expected=");
+    print_bits_r(expected);
+    printf("res_dec =");
     print_bits_r(res);
 #endif
 
     /* HACK: res == res */
-    ck_assert_float_eq(s21_is_equal(res, res), TRUE);
+    ck_assert_float_eq(s21_is_equal(expected, res), TRUE);
     ck_assert_int_eq(ret, CONVERTATION_OK);
 }
 END_TEST
@@ -27,7 +38,7 @@ Suite *suite_s21_truncate(void) {
     Suite *s = suite_create("suite_s21_truncate");
     TCase *tc = tcase_create("s21_truncate_tc");
 
-    tcase_add_loop_test(tc, simple_truncate, 0, 1);
+    tcase_add_loop_test(tc, gcc_128_bits, 0, 10000);
 
     suite_add_tcase(s, tc);
     return s;

--- a/src/tests/s21_decimal_test.h
+++ b/src/tests/s21_decimal_test.h
@@ -41,6 +41,7 @@ void mpz_sint_sum(mpz_t *res, int64_t compound_val);
 s21_decimal bigint_to_decimal(__int128_t src);
 s21_decimal ll_to_decimal(long long val);
 long long get_random_ll(void);
+__int128_t int128_pow(int val, int exp);
 
 short int get_random_short(void);
 
@@ -59,6 +60,7 @@ void print_bits_r_set(s21_decimal d, int set_n);
 void print_bits(s21_decimal d);
 void print_bits_r(s21_decimal d);
 void print_bits_no_exp(s21_decimal d);
+void debug_print_pair(s21_decimal *dec, mpz_t *big, bool exp_applied);
 
 /* Our functions test */
 Suite *suite_convert_gmp_to_decimal(void);

--- a/src/tests/test_runner.c
+++ b/src/tests/test_runner.c
@@ -16,7 +16,8 @@ int main(void) {
 void run_testcase(Suite *testcase) {
     static int counter_testcase = 1;
 
-    if (counter_testcase > 1) putchar('\n');
+    if (counter_testcase > 1)
+        putchar('\n');
     printf(GRN "%s%d%s" ENDCOLOR, "CURRENT TEST: ", counter_testcase, "\n");
     counter_testcase++;
 
@@ -33,15 +34,15 @@ void run_testcase(Suite *testcase) {
 void run_tests(void) {
     Suite *list_cases[] = {
 
-        // suite_s21_mul(), //
-        // suite_s21_floor(), //
+        // suite_s21_mul(),
+        // suite_s21_round(),
 
-        suite_s21_mod(),  // 🌱 [ FEW TESTS FAILED ]
-        suite_s21_div(),  // 🌱 [ FEW TESTS FAILED ]
+        // suite_s21_mod(),  // 🌱 [ FEW TESTS FAILED ]
+        // suite_s21_div(),  // 🌱 [ FEW TESTS FAILED ]
         // suite_s21_is_less(), // 🌱 [ FEW TESTS FAILED ]
-        // suite_s21_truncate(), // 🌱 [ Needs DIV & tests<gmp> ]
-        // suite_s21_round(), // 🌱 [ Needs truncate & tests<gmp> ]
+        // suite_s21_floor(), // 🌱 [ Needs truncate & tests<gmp> ]
 
+        // suite_s21_truncate(),  // ✅
         // suite_s21_from_int_to_decimal(),  // ✅
         // suite_s21_add(),  // ✅
         // suite_s21_sub(),  // ✅
@@ -57,7 +58,8 @@ void run_tests(void) {
         // suite_s21_negate(),  // ✅
         NULL};
 
-    for (Suite **current_testcase = list_cases; *current_testcase != NULL; current_testcase++) {
+    for (Suite **current_testcase = list_cases; *current_testcase != NULL;
+         current_testcase++) {
         run_testcase(*current_testcase);
     }
 }


### PR DESCRIPTION
- Signature fix int -> unsigned to match our bits[4]
- added int128_pow for rounding functions
- Expanded debug_print_pair scope. Used it for tests. Given up. get_random_pair doesn't seem to work correctly. Maybe give up on GMP?
- Restructured a little, commented out unfinished code
- All tests are implemented using int128_t [Works well]
- Added signatures for int128_pow & debug_print
- Updated our progress with tests
